### PR TITLE
Solution of `all-settled`

### DIFF
--- a/js-exercises/all-settled/README.md
+++ b/js-exercises/all-settled/README.md
@@ -1,0 +1,40 @@
+# Instructions
+
+The `allSettled` method returns a promise that resolves after all of the given promises have either fulfilled or rejected, with an array of objects that each describes the outcome of each promise.
+
+## Examples 
+
+```js
+allSettled([
+  Promise.resolve(33),
+  new Promise(resolve => setTimeout(() => resolve(66), 0)),
+  99,
+  Promise.reject(new Error('an error'))
+])
+.then(values => console.log(values));
+
+// [
+//   {status: "fulfilled", value: 33},
+//   {status: "fulfilled", value: 66},
+//   {status: "fulfilled", value: 99},
+//   {status: "rejected",  reason: Error: an error}
+// ]
+```
+
+```js
+const promise1 = Promise.resolve(3);
+const promise2 = new Promise((resolve, reject) => setTimeout(reject, 100, 'foo'));
+const promises = [promise1, promise2];
+
+allSettled(promises).
+  then((results) => results.forEach((result) => console.log(result.status)));
+
+// expected output:
+// "fulfilled"
+// "rejected"
+
+```
+
+# Restrictions
+- Don't use `Promise.allSettled` or `Promise.all`
+- You can use built-in `Promise` constructor.

--- a/js-exercises/all-settled/allSettled.js
+++ b/js-exercises/all-settled/allSettled.js
@@ -1,0 +1,107 @@
+const STATUS_FULFILLED = 'fulfilled';
+const STATUS_REJECTED = 'rejected';
+
+function isIterable(iterable) {
+  return iterable && iterable[Symbol.iterator] && typeof iterable[Symbol.iterator] === 'function'
+}
+
+
+function promisify(value) {
+  if (value instanceof Promise) {
+    return value;
+  }
+  return Promise.resolve(value)
+}
+
+
+function allSettled(iterable) {
+  if (!isIterable(iterable)) {
+    throw new TypeError(`${promises} is not an iterable, cannot read [Symbol.iterator]()`);
+  }
+
+  const elements = [...iterable];
+  const element = elements.shift();
+  const promise = promisify(element);
+
+  return new Promise(async resolve => {
+    let restPromisesValue;
+    let promiseValue;
+
+    function tryResolvingThisPromise() { //* move this func out
+      if (promiseValue){
+        if (!elements.length) {
+          resolve([promiseValue]);
+        }
+        else if (restPromisesValue) {
+          resolve([promiseValue, ...restPromisesValue]);
+        }
+      }
+    }
+
+    promise.then(value => {
+      promiseValue = { status: STATUS_FULFILLED, value };
+      tryResolvingThisPromise();
+    }).catch(reason => {
+      promiseValue = { state: STATUS_REJECTED, reason };
+      tryResolvingThisPromise();
+    })
+
+    restPromisesValue = elements.length ? await allSettled(elements) : []
+    tryResolvingThisPromise();
+
+  });
+}
+
+
+
+//! The following implementation fails for unhandled async rejections
+
+// async function allSettled(iterable) {
+//   if (!isIterable(iterable)) {
+//     throw new TypeError(`${promises} is not an iterable, cannot read`)
+//   }
+
+//   const promises = iterable.map(promisify);
+
+//   const result = []
+//   for (let promise of promises) {
+//     const r = {}
+//     try {
+//       r.status = STATUS_FULFILLED;
+//       r.value = await promise;
+//     }
+//     catch (e) {
+//       r.status = STATUS_REJECTED;
+//       r.reason = `${e}`;
+//     }
+//     result.push(r);
+//   }
+
+//   return result;
+// }
+
+
+
+
+
+//! Test Case
+
+// async function main(){
+// console.log(await allSettled([
+//   Promise.resolve(33),
+//   Promise.resolve(33),
+//   Promise.reject(33),
+//   Promise.resolve(33),
+//   new Promise((resolve, reject) => setTimeout(() => reject(66), 1000)),
+//   99,
+//   99,
+//   99,
+//   99,
+//   Promise.reject(new Error('an error')),
+//   Promise.reject(new Error('an error')),
+// ]))}
+
+// main();
+
+
+export { allSettled };

--- a/js-exercises/all-settled/allSettled.test.js
+++ b/js-exercises/all-settled/allSettled.test.js
@@ -1,0 +1,80 @@
+import { allSettled } from './allSettled'
+
+describe('allSettled', () => {
+
+  it('should satisfy README test cases - 1', async () => {
+
+    expect(await allSettled([
+      Promise.resolve(33),
+      new Promise(resolve => setTimeout(() => resolve(66), 0)),
+      99,
+      Promise.reject(new Error('an error'))
+    ])).toEqual(
+      [
+        { status: "fulfilled", value: 33 },
+        { status: "fulfilled", value: 66 },
+        { status: "fulfilled", value: 99 },
+        { status: "rejected", reason: 'Error: an error' }
+      ]
+    )
+  })
+
+  it('should satisfy README test cases - 2', async () => {
+
+    const promise1 = Promise.resolve(3);
+    const promise2 = new Promise((resolve, reject) => setTimeout(reject, 100, 'foo'));
+    const promises = [promise1, promise2];
+
+    expect(await allSettled(promises)).toEqual(
+      [
+        { status: "fulfilled", value: 3 },
+        { status: "rejected", reason: 'foo' }
+      ]
+    )
+  })
+
+  it('should handle first rejected promises', async () => {
+
+    expect(await allSettled([
+      Promise.reject(new Error('an error')),
+      Promise.reject(new Error('an error')),
+
+      Promise.reject(new Error('an error')),
+      Promise.resolve(33),
+      new Promise((resolve, reject) => setTimeout(() => reject(66), 0)),
+      99,
+    ])).toEqual(
+      [
+        { status: 'rejected', reason: 'Error: an error' },
+        { status: 'rejected', reason: 'Error: an error' },
+        { status: 'rejected', reason: 'Error: an error' },
+        { status: 'fulfilled', value: 33 },
+        { status: 'rejected', reason: '66' },
+        { status: 'fulfilled', value: 99 },
+      ]
+    )
+  })
+
+  it('should handle async rejected promises', async () => {
+
+    expect(await allSettled([
+      Promise.reject(new Error('an error')),
+      Promise.reject(new Error('an error')),
+      Promise.resolve(33),
+      new Promise((resolve, reject) => setTimeout(() => reject(66), 0)),
+      99,
+      Promise.reject(new Error('an error'))
+    ])).toEqual(
+      [
+        { status: 'rejected', reason: 'Error: an error' },
+        { status: 'rejected', reason: 'Error: an error' },
+        { status: 'fulfilled', value: 33 },
+        { status: 'rejected', reason: '66' },
+        { status: 'fulfilled', value: 99 },
+        { status: 'rejected', reason: 'Error: an error' },
+      ]
+    )
+  })
+
+
+})


### PR DESCRIPTION
### all-settle
This problem was one of the trickiest one so far. It made me realise how important Promise.all and Promise.allSettled are. I am still not sure what actual implementation for this problem is in the browser's implementation. 

I tried using normal for-of loop but it wasn't handling async rejections properly. 
So I had to rewrite it using recursion with some ugly logic. 

